### PR TITLE
Fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,15 +19,18 @@ matrix:
           - git
       script:
         - git clone https://github.com/stevengj/libctl
-        - (cd libctl && git checkout 7d51710e63952d343ce8f241cf92b5cbfd5f1ada && sh autogen.sh --prefix=$HOME/local && make && make install)
+        - (cd libctl && git checkout master && sh autogen.sh --prefix=$HOME/local && make && make install)
         - sh autogen.sh --enable-maintainer-mode --prefix=$HOME/local --with-libctl=$HOME/local/share/libctl GEN_CTL_IO=$HOME/local/bin/gen-ctl-io CPPFLAGS=-I$HOME/local/include LDFLAGS=-L$HOME/local/lib
         - make && make check && make install
     - os: osx
       install:
         - brew tap homebrew/science
         - brew update
-        - brew install guile fftw lapack libctl
+        - brew cask uninstall oclint # travis issue #8826
+        - brew install guile fftw lapack
       script:
+        - git clone https://github.com/stevengj/libctl
+        - (cd libctl && git checkout master && sh autogen.sh --prefix=$HOME/local && make && make install)
         - sh autogen.sh --prefix=$HOME/local --with-hermitian-eps
         - make && make check && make install
         - ./configure --prefix=$HOME/local --with-inv-symmetry

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
       script:
         - git clone https://github.com/stevengj/libctl
         - (cd libctl && git checkout master && sh autogen.sh --prefix=$HOME/local && make && make install)
-        - sh autogen.sh --prefix=$HOME/local --with-hermitian-eps
+        - sh autogen.sh --prefix=$HOME/local --with-hermitian-eps --with-libctl=$HOME/local/share/libctl GEN_CTL_IO=$HOME/local/bin/gen-ctl-io CPPFLAGS=-I$HOME/local/include LDFLAGS=-L$HOME/local/lib
         - make && make check && make install
-        - ./configure --prefix=$HOME/local --with-inv-symmetry
+        - ./configure --prefix=$HOME/local --with-inv-symmetry --with-libctl=$HOME/local/share/libctl GEN_CTL_IO=$HOME/local/bin/gen-ctl-io CPPFLAGS=-I$HOME/local/include LDFLAGS=-L$HOME/local/lib
         - make && make check && make install


### PR DESCRIPTION
Builds were failing because they weren't getting the latest libctl 4.0.0.
@stevengj @oskooi 