### PR TITLE
update docs with PyMeep installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,20 @@
 [![Latest Docs](https://readthedocs.org/projects/pip/badge/?version=latest)](http://mpb.readthedocs.io/en/latest/)
 [![Build Status](https://travis-ci.org/stevengj/mpb.svg?branch=master)](https://travis-ci.org/stevengj/mpb)
 
-MPB is a free software package for computing photonic band structures and modes.
+MPB is a free and open-source software package for computing electromagnetic band structures and modes.
 
-See the documenatation on [readthedocs](https://mpb.readthedocs.io/) for
-a complete description of the package and its user interface, as
-well as installation instructions, the license and copyright, and
-other information.
+**Features**
 
-Official MPB releases can be found on the [releases page](https://github.com/stevengj/mpb/releases).  See the [Installation section of the manual](http://mpb.readthedocs.io/en/latest/Installation/) for information.
+-   **Free and open-source software** under the [GNU GPL](https://en.wikipedia.org/wiki/GNU_General_Public_License).
+-   Complete **scriptability** via [Python](Python_Tutorial) or [Scheme](Scheme_User_Interface) APIs.
+-   Portable to any Unix-like system such as [Linux](https://en.wikipedia.org/wiki/Linux), [macOS](https://en.wikipedia.org/wiki/MacOS), and [FreeBSD](https://en.wikipedia.org/wiki/FreeBSD).
+-   Distributed memory **parallelism** on any system supporting the [MPI](https://en.wikipedia.org/wiki/Message_Passing_Interface) standard.
+-   Fully-vectorial **1d, 2d, 3d** calculations. Iterative eigensolver techniques are employed to make large calculations possible.
+-   **Direct, frequency-domain eigensolver** as opposed to indirect methods, e.g. time-domain. This means that you get both eigenvalues (frequencies) and eigenstates (electromagnetic modes) at the same time. See [comparison of time-domain and frequency-domain techniques](Introduction.md#frequency-domain-vs-time-domain).
+-   **Targeted eigensolver**. Iterative eigensolvers normally compute states (harmonic modes) with the lowest few frequencies. MPB can alternatively compute the modes whose frequencies are closest to a specified target frequency. This greatly reduces the number of bands that must be computed in guided or resonant mode calculations.
+-   Support for arbitrary, **anisotropic** dielectrics including **gyrotropic/magneto-optic** materials and **non-orthogonal** unit cells.
+-   Field output in the [HDF5](https://support.hdfgroup.org/HDF5/) data format.
 
-For developers wishing to hack on the latest version, to build MPB from git (on a Unix-like system), do:
-```
-git clone git://github.com/stevengj/mpb
-cd mpb
-sh autogen.sh
-make
-```
-To build it, you will need various dependencies installed as described
-in the [MPB Installation Manual](https://mpb.readthedocs.io/en/latest/Installation/)
+# Documentation
+
+See the [manual on readthedocs](https://mpb.readthedocs.io/en/latest) for the latest documentation.

--- a/doc/docs/Installation.md
+++ b/doc/docs/Installation.md
@@ -296,4 +296,82 @@ make distclean
 Python
 -------
 
-The Python inteface to MPB depends on [MEEP](http://github.com/stevengj/meep) and can currently only be built as part of MEEP. Complete build instructions for MEEP, including the Python MPB interface, can be found [here](http://meep.readthedocs.io/en/latest/Installation/#building-from-source). Eventually, the dependency on MEEP will be removed, and the Python interface will be available from the MPB repository.
+The Python inteface to MPB depends on [MEEP](http://github.com/stevengj/meep) and can currently only be built as part of MEEP. Eventually, the dependency on MEEP will be removed, and the Python interface will be available from the MPB repository.
+
+The following instructions are for building parallel PyMeep with serial PyMPB from source on Ubuntu 16.04. The parallel version can still be run serially by running a script with just `python` instead of `mpirun -np 4 python`. If you really don't want to install MPI and parallel HDF5, just replace `libhdf5-openmpi-dev` with `libhdf5-dev`, and remove the `--with-mpi`, `CC=mpicc`, and `CPP=mpicxx` flags. The paths to HDF5 will also need to be adjusted to `/usr/lib/x86_64-linux-gnu/hdf5/serial` and `/usr/include/hdf5/serial`. Note that this script builds with Python 3 by default. If you want to use Python 2, just point the `PYTHON` variable to the appropriate interpreter when calling `autogen.sh` for building Meep, and use `pip` instead of `pip3`.
+
+```bash
+#!/bin/bash
+
+set -e
+
+RPATH_FLAGS="-Wl,-rpath,/usr/local/lib:/usr/lib/x86_64-linux-gnu/hdf5/openmpi"
+MY_LDFLAGS="-L/usr/local/lib -L/usr/lib/x86_64-linux-gnu/hdf5/openmpi ${RPATH_FLAGS}"
+MY_CPPFLAGS="-I/usr/local/include -I/usr/include/hdf5/openmpi"
+
+sudo apt-get update
+sudo apt-get -y install     \
+    libblas-dev             \
+    liblapack-dev           \
+    libgmp-dev              \
+    swig                    \
+    libgsl-dev              \
+    autoconf                \
+    pkg-config              \
+    libpng16-dev            \
+    git                     \
+    guile-2.0-dev           \
+    libfftw3-dev            \
+    libhdf5-openmpi-dev     \
+    hdf5-tools              \
+    libpython3.5-dev        \
+    python3-numpy           \
+    python3-scipy           \
+    python3-matplotlib      \
+    python3-pip             \
+
+mkdir -p ~/install
+
+cd ~/install
+git clone https://github.com/stevengj/harminv.git
+cd harminv/
+sh autogen.sh --enable-shared
+make && sudo make install
+
+cd ~/install
+git clone https://github.com/stevengj/libctl.git
+cd libctl/
+sh autogen.sh --enable-shared
+make && sudo make install
+
+cd ~/install
+git clone https://github.com/stevengj/h5utils.git
+cd h5utils/
+sh autogen.sh CC=mpicc LDFLAGS="${MY_LDFLAGS}" CPPFLAGS="${MY_CPPFLAGS}"
+make && sudo make install
+
+cd ~/install
+git clone https://github.com/stevengj/mpb.git
+cd mpb/
+sh autogen.sh --enable-shared CC=mpicc LDFLAGS="${MY_LDFLAGS}" CPPFLAGS="${MY_CPPFLAGS}" --with-hermitian-eps
+make && sudo make install
+
+sudo pip3 install --upgrade pip
+pip3 install --user --no-cache-dir mpi4py
+export HDF5_MPI="ON"
+pip3 install --user --no-binary=h5py h5py
+
+cd ~/install
+git clone https://github.com/stevengj/meep.git
+cd meep/
+sh autogen.sh --enable-shared --with-mpi PYTHON=python3 \
+    CC=mpicc CXX=mpic++ LDFLAGS="${MY_LDFLAGS}" CPPFLAGS="${MY_CPPFLAGS}"
+make && sudo make install
+```
+
+You may want to add the following line to your `.profile` so Python can always find the meep package:
+
+```bash
+export PYTHONPATH=/usr/local/lib/python3.5/site-packages
+```
+

--- a/doc/docs/index.md
+++ b/doc/docs/index.md
@@ -10,14 +10,14 @@ Features
 --------
 
 -   **Free and open-source software** under the [GNU GPL](https://en.wikipedia.org/wiki/GNU_General_Public_License).
--   Complete **scriptability** via [Python](Python_Tutorial) or [Scheme](Scheme_User_Interface).
--   Portable to any Unix-like system such as [Linux](https://en.wikipedia.org/wiki/Linux) and [macOS](https://en.wikipedia.org/wiki/MacOS).
+-   Complete **scriptability** via [Python](Python_Tutorial) or [Scheme](Scheme_User_Interface) APIs.
+-   Portable to any Unix-like system such as [Linux](https://en.wikipedia.org/wiki/Linux), [macOS](https://en.wikipedia.org/wiki/MacOS), and [FreeBSD](https://en.wikipedia.org/wiki/FreeBSD).
 -   Distributed memory **parallelism** on any system supporting the [MPI](https://en.wikipedia.org/wiki/Message_Passing_Interface) standard.
 -   Fully-vectorial **1d, 2d, 3d** calculations. Iterative eigensolver techniques are employed to make large calculations possible.
 -   **Direct, frequency-domain eigensolver** as opposed to indirect methods, e.g. time-domain. This means that you get both eigenvalues (frequencies) and eigenstates (electromagnetic modes) at the same time. See [comparison of time-domain and frequency-domain techniques](Introduction.md#frequency-domain-vs-time-domain).
 -   **Targeted eigensolver**. Iterative eigensolvers normally compute states (harmonic modes) with the lowest few frequencies. MPB can alternatively compute the modes whose frequencies are closest to a specified target frequency. This greatly reduces the number of bands that must be computed in guided or resonant mode calculations.
 -   Support for arbitrary, **anisotropic** dielectrics including **gyrotropic/magneto-optic** materials and **non-orthogonal** unit cells.
--   Field output in [HDF5](https://support.hdfgroup.org/HDF5/) format supported by many visualization tools.
+-   Field output in the [HDF5](https://support.hdfgroup.org/HDF5/) data format.
 
 To give you some feel for how long these calculations take, let us consider one typical data point. For the 3d band-structure of a [diamond lattice of dielectric spheres in air](Data_Analysis_Tutorial.md#diamond-lattice-of-spheres), computing the lowest 10 bands on a 16×16×16 grid at 31 k-points, MPB took 8 seconds on a 2.8 GHz AMD Opteron under Debian with the [ATLAS](http://www.netlib.org/atlas/) optimized BLAS library. Thus, at each k-point, MPB was minimizing a function with 81920 degrees of freedom in 0.26 seconds on average.
 


### PR DESCRIPTION
Add installation instructions for building PyMeep from source (mirrored from the Meep docs) since currently PyMeep is a dependency for PyMPB.

Closes #55 and closes #56.