### PR TITLE
Updated mkdocs syntax to be compatible with v.0.17.5

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,9 +5,10 @@ repo_url: https://github.com/stevengj/mpb/
 docs_dir: 'doc/docs'
 site_dir: 'doc/site'
 
-theme_dir: 'doc/mpb-mkdocs-theme'
-theme: readthedocs
-
+theme:
+  name: readthedocs
+  custom_dir: mpb-mkdocs-theme
+  
 python:
    version: 2 # for unicode
    setup_py_install: True


### PR DESCRIPTION
The build didn't work with the old (deprecated) syntax.  Fixes #59