### PR TITLE
oclint is no longer installed by default in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,5 +66,4 @@ matrix:
         - INV_SYM=--with-inv-symmetry
       install:
         - brew update
-        - brew cask uninstall oclint # travis issue #8826
         - brew install guile fftw lapack


### PR DESCRIPTION
The travis issue requiring this has been resolved.
@stevengj @oskooi 